### PR TITLE
Update vendor.json - Ignore appengine, update fake-gcs-server/fakestorage

### DIFF
--- a/vendor/github.com/fsouza/fake-gcs-server/fakestorage/bucket.go
+++ b/vendor/github.com/fsouza/fake-gcs-server/fakestorage/bucket.go
@@ -24,6 +24,34 @@ func (s *Server) CreateBucket(name string) {
 	}
 }
 
+// createBucketByPost handles a POST request to create a bucket
+func (s *Server) createBucketByPost(w http.ResponseWriter, r *http.Request) {
+	// Minimal version of Bucket from google.golang.org/api/storage/v1
+	var data struct {
+		Name string
+	}
+
+	// Read the bucket name from the request body JSON
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&data); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	name := data.Name
+
+	// Create the named bucket
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	if err := s.backend.CreateBucket(name); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Return the created bucket:
+	resp := newBucketResponse(name)
+	json.NewEncoder(w).Encode(resp)
+}
+
 func (s *Server) listBuckets(w http.ResponseWriter, r *http.Request) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()

--- a/vendor/github.com/fsouza/fake-gcs-server/fakestorage/response.go
+++ b/vendor/github.com/fsouza/fake-gcs-server/fakestorage/response.go
@@ -4,9 +4,7 @@
 
 package fakestorage
 
-import (
-	"sort"
-)
+import "sort"
 
 type listResponse struct {
 	Kind     string        `json:"kind"`

--- a/vendor/github.com/fsouza/fake-gcs-server/fakestorage/server.go
+++ b/vendor/github.com/fsouza/fake-gcs-server/fakestorage/server.go
@@ -130,17 +130,14 @@ func (s *Server) buildMuxer() {
 	s.mux.Host("{bucketName}.storage.googleapis.com").Path("/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 	r := s.mux.PathPrefix("/storage/v1").Subrouter()
 	r.Path("/b").Methods("GET").HandlerFunc(s.listBuckets)
+	r.Path("/b").Methods("POST").HandlerFunc(s.createBucketByPost)
 	r.Path("/b/{bucketName}").Methods("GET").HandlerFunc(s.getBucket)
 	r.Path("/b/{bucketName}/o").Methods("GET").HandlerFunc(s.listObjects)
 	r.Path("/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.getObject)
 	r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)
 	r.Path("/b/{sourceBucket}/o/{sourceObject:.+}/rewriteTo/b/{destinationBucket}/o/{destinationObject:.+}").HandlerFunc(s.rewriteObject)
-
-	// Download path
 	s.mux.Path("/download/storage/v1/b/{bucketName}/o/{objectName}").Methods("GET").HandlerFunc(s.downloadObject)
-
-	// Upload
 	s.mux.Path("/upload/storage/v1/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	s.mux.Path("/upload/resumable/{uploadId}").Methods("PUT", "POST").HandlerFunc(s.uploadFileContent)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,19 +1,7 @@
 {
 	"comment": "",
-	"ignore": "test",
+	"ignore": "test appengine",
 	"package": [
-		{
-			"path": "appengine",
-			"revision": ""
-		},
-		{
-			"path": "appengine_internal",
-			"revision": ""
-		},
-		{
-			"path": "appengine_internal/base",
-			"revision": ""
-		},
 		{
 			"checksumSHA1": "b1KgRkWqz0RmrEBK6IJ8kOJva6w=",
 			"path": "cloud.google.com/go/compute/metadata",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2019-03-26T12:33:24Z"
 		},
 		{
-			"checksumSHA1": "F2epjsNy7YxZBTtbpvMEMO4ZGjU=",
+			"checksumSHA1": "bKbj221nscYkDK8bjUcFvrPYyRU=",
 			"path": "github.com/fsouza/fake-gcs-server/fakestorage",
-			"revision": "65e9489b35203d3ac602982cd4a6712d9ca13980",
-			"revisionTime": "2019-03-26T16:48:08Z"
+			"revision": "6a18602b15014501f0f83096ec46b38e2b059047",
+			"revisionTime": "2019-05-31T12:59:19Z"
 		},
 		{
 			"checksumSHA1": "Te//OY7T9yXNI8erkUWIp/gqnjY=",


### PR DESCRIPTION
* Remove ``appengine`` from ``vendor/vendor.json``, as suggested by [govendor FAQ](https://github.com/kardianos/govendor/blob/master/doc/faq.md#q-im-getting-missing-packages-from-appengine-but-i-dont-care-about-appengine-how-do-i-ignore-these-packages)
* Update to latest https://github.com/fsouza/fake-gcs-server, which includes the ability to create a bucket via ``POST``, which may help with issue #1.

I suspect we shouldn't check in the vendor subfolders as well ([govendor FAQ again](https://github.com/kardianos/govendor/blob/master/doc/faq.md#q-how-do-i-prevent-vendor-source-from-being-checked-in)), but that can be a future PR.