### PR TITLE
Create empty /storage directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.5
 MAINTAINER Matteo Scandolo <teo.punto@gmail.com>
 
 COPY --from=builder /build/go-fake-storage /service/go-fake-storage
+RUN mkdir /storage
 
 EXPOSE 4443
 


### PR DESCRIPTION
If you pre-load data by mounting a volume at ``/data``, then the ``/storage`` directory is created. If you omit this mount, this will ensure the ``/storage`` folder exists.

Without this, calling ``client.list_buckets()`` with the Python library raises an exception:

```
Traceback (most recent call last):
  File "./client-test.py", line 38, in <module>
    list_buckets('FILES AT START')
  File "./client-test.py", line 31, in list_buckets
    for bucket in client.list_buckets():
  File "/usr/local/lib/python3.7/site-packages/google/api_core/page_iterator.py", line 204, in _items_iter
    for page in self._page_iter(increment=False):
  File "/usr/local/lib/python3.7/site-packages/google/api_core/page_iterator.py", line 235, in _page_iter
    page = self._next_page()
  File "/usr/local/lib/python3.7/site-packages/google/api_core/page_iterator.py", line 361, in _next_page
    response = self._get_next_page_response()
  File "/usr/local/lib/python3.7/site-packages/google/api_core/page_iterator.py", line 411, in _get_next_page_response
    method=self._HTTP_METHOD, path=self.path, query_params=params
  File "/usr/local/lib/python3.7/site-packages/google/cloud/_http.py", line 319, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.InternalServerError: 500 GET https://server:4443/storage/v1/b?project=test&projection=noAcl: open /storage/: no such file or directory
```
